### PR TITLE
Add:添加一些过滤规则，这些文件不能被打成AB

### DIFF
--- a/KEngine.UnityProject/Assets/KEngine.Editor/Editor/BuildTools.cs
+++ b/KEngine.UnityProject/Assets/KEngine.Editor/Editor/BuildTools.cs
@@ -61,6 +61,20 @@ namespace KEngine.Editor
             }
         }
 
+        //以下规则不需要被ab处理//
+        public static bool IfOneNameNeed2AssetBundle(string pathName)
+        {
+            var checkName = pathName.ToLower();
+            if (checkName.EndsWith(".meta")
+                || checkName.Contains(("LightingData").ToLower())
+                || checkName.Contains(("DS_Store").ToLower())
+                || checkName.EndsWith(".cs")
+                || checkName.EndsWith(".dll")
+                //  || checkName.Contains("navmesh")
+            )
+                return false;
+            return true;
+        }
         /// <summary>
         /// Unity 5新AssetBundle系统，需要为打包的AssetBundle配置名称
         /// 
@@ -113,7 +127,8 @@ namespace KEngine.Editor
             {
                 EditorUtility.DisplayProgressBar("AssetBundle", string.Format("Making asset bundle name: {0}", filepath), .5f);
 
-                if (filepath.EndsWith(".meta")) continue;
+                if (IfOneNameNeed2AssetBundle(filepath) == false)
+                    continue;
 
                 var importer = AssetImporter.GetAtPath(filepath);
                 if (importer == null)

--- a/KEngine.UnityProject/Assets/KEngine/CoreModules/ResourceModule/KAssetBundleLoader.cs
+++ b/KEngine.UnityProject/Assets/KEngine/CoreModules/ResourceModule/KAssetBundleLoader.cs
@@ -96,10 +96,11 @@ namespace KEngine
         private static AssetBundleManifest _assetBundleManifest;
         /// <summary>
         /// Unity5下，使用manifest进行AssetBundle的加载
+        /// bool isForce,在热更新后，可能需要强制刷新AssetBundleManifest。
         /// </summary>
-        static void PreLoadManifest()
+        public static void PreLoadManifest(bool isForce = false)
         {
-            if (_hasPreloadAssetBundleManifest)
+            if (_hasPreloadAssetBundleManifest && isForce == false)
                 return;
 
             _hasPreloadAssetBundleManifest = true;


### PR DESCRIPTION
在unity5的打包系统中，包含这些后缀的文件不需要被打包，有部分会使dependency为空，导致loader处理依赖时为null。