### PR TITLE
GetAssetBytes 存在溢出问题

### DIFF
--- a/KEngine.UnityProject/Assets/KEngine/CoreModules/ResourceModule/KEngineAndroidPlugin.cs
+++ b/KEngine.UnityProject/Assets/KEngine/CoreModules/ResourceModule/KEngineAndroidPlugin.cs
@@ -87,7 +87,20 @@ namespace KEngine
         public static string GetAssetString(string path)
         {
 #if !KENGINE_DLL && UNITY_ANDROID
+#if UNITY_2017
+            var clsPtr = AndroidJNI.FindClass("com/github/KEngine/AndroidHelper");
+            var methondPtr_getAssetBytes = AndroidJNIHelper.GetMethodID(clsPtr, "getAssetBytes", "(Ljava/lang/String;)[B", true);
+            var arg1 = new object[] { path };
+            var args = AndroidJNIHelper.CreateJNIArgArray(arg1);
+            var byteArray = AndroidJNI.CallStaticObjectMethod(clsPtr, methondPtr_getAssetBytes, args);
+            var bytes = AndroidJNI.FromByteArray(byteArray);
+            AndroidJNIHelper.DeleteJNIArgArray(arg1, args);
+            AndroidJNI.DeleteLocalRef(byteArray);
+            AndroidJNI.DeleteLocalRef(clsPtr);
+            return bytes;
+#else
             return AndroidHelper.CallStatic<string>("getAssetString", path);
+#endif
 #else
             ErrorNotSupport();
             return null;


### PR DESCRIPTION
直接用 AndroidHelper.CallStatic<byte[]>("getAssetBytes", path);
会导致 java 中的 byte[] 无法释放。
当达到一定数量的时候，某些机型会出现如下错误
E/dalvikvm(22437): JNI ERROR (app bug): local reference table overflow (max=512)
W/dalvikvm(22437): JNI local reference table (0x67e80010) dump:

需要手动在C#层执行DeleteLocalRef。